### PR TITLE
Rename SVProgressHUD class

### DIFF
--- a/SVProgressHUD/SVIndefiniteAnimatedView.m
+++ b/SVProgressHUD/SVIndefiniteAnimatedView.m
@@ -6,7 +6,7 @@
 //
 
 #import "SVIndefiniteAnimatedView.h"
-#import "SVProgressHUD.h"
+#import "SVProgressHUDView.h"
 
 @interface SVIndefiniteAnimatedView ()
 

--- a/SVProgressHUD/SVProgressHUDView.h
+++ b/SVProgressHUD/SVProgressHUDView.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 typedef void (^SVProgressHUDShowCompletion)(void);
 typedef void (^SVProgressHUDDismissCompletion)(void);
 
-@interface SVProgressHUD : UIView
+@interface SVProgressHUDView : UIView
 
 #pragma mark - Customization
 

--- a/SVProgressHUD/SVProgressHUDView.m
+++ b/SVProgressHUD/SVProgressHUDView.m
@@ -9,7 +9,7 @@
 #error SVProgressHUD is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
 #endif
 
-#import "SVProgressHUD.h"
+#import "SVProgressHUDView.h"
 #import "SVIndefiniteAnimatedView.h"
 #import "SVProgressAnimatedView.h"
 #import "SVRadialGradientLayer.h"
@@ -31,7 +31,7 @@ static const CGFloat SVProgressHUDHorizontalSpacing = 12.0f;
 static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 
-@interface SVProgressHUD ()
+@interface SVProgressHUDView ()
 
 @property (nonatomic, strong) NSTimer *graceTimer;
 @property (nonatomic, strong) NSTimer *fadeOutTimer;
@@ -60,14 +60,14 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 @end
 
-@implementation SVProgressHUD {
+@implementation SVProgressHUDView {
     BOOL _isInitializing;
 }
 
-+ (SVProgressHUD*)sharedView {
++ (SVProgressHUDView*)sharedView {
     static dispatch_once_t once;
     
-    static SVProgressHUD *sharedView;
+    static SVProgressHUDView *sharedView;
 #if !defined(SV_APP_EXTENSIONS)
     dispatch_once(&once, ^{ sharedView = [[self alloc] initWithFrame:[[[UIApplication sharedApplication] delegate] window].bounds]; });
 #else
@@ -758,9 +758,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 #pragma mark - Master show/dismiss methods
 
 - (void)showProgress:(float)progress status:(NSString*)status {
-    __weak SVProgressHUD *weakSelf = self;
+    __weak SVProgressHUDView *weakSelf = self;
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        __strong SVProgressHUD *strongSelf = weakSelf;
+        __strong SVProgressHUDView *strongSelf = weakSelf;
         if(strongSelf){
             if(strongSelf.fadeOutTimer) {
                 strongSelf.activityCount = 0;
@@ -838,9 +838,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 - (void)showImage:(UIImage*)image status:(NSString*)status duration:(NSTimeInterval)duration {
-    __weak SVProgressHUD *weakSelf = self;
+    __weak SVProgressHUDView *weakSelf = self;
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        __strong SVProgressHUD *strongSelf = weakSelf;
+        __strong SVProgressHUDView *strongSelf = weakSelf;
         if(strongSelf){
             // Stop timer
             strongSelf.fadeOutTimer = nil;
@@ -984,9 +984,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 - (void)dismissWithDelay:(NSTimeInterval)delay completion:(SVProgressHUDDismissCompletion)completion {
-    __weak SVProgressHUD *weakSelf = self;
+    __weak SVProgressHUDView *weakSelf = self;
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        __strong SVProgressHUD *strongSelf = weakSelf;
+        __strong SVProgressHUDView *strongSelf = weakSelf;
         if(strongSelf){
             
             // Post notification to inform user


### PR DESCRIPTION
This is a fix for the following error that Xcode 12.5 generates. An alternative to PR  https://github.com/StreetEasy/SVProgressHUD/pull/2
```
target 'SVProgressHUD' has invalid header layout: umbrella header found at '/Users/glenb/Code/SVProgressHUD/SVProgressHUD/SVProgressHUD.h', but directories exist next to it: /Users/glenb/Code/SVProgressHUD/SVProgressHUD/Images.xcassets; consider removing them
```
Xcode seems to think that a header file with the same name as the target must be an umbrella header. I renamed the `SVProgressHUD` class so that Xcode won't get confused.